### PR TITLE
feat!: No longer rely on global 'game' variable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gtp",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gtp",
-      "version": "4.1.0",
+      "version": "5.0.0",
       "license": "MIT",
       "devDependencies": {
         "@stylistic/eslint-plugin": "5.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gtp",
-  "version": "4.1.2",
+  "version": "5.0.0",
   "license": "MIT",
   "type": "module",
   "repository": {

--- a/src/gtp/BitmapFont.spec.ts
+++ b/src/gtp/BitmapFont.spec.ts
@@ -1,7 +1,17 @@
-import { BitmapFont, Game, Image } from '../index.js';
-import { Window } from './GtpBase.js';
+import { beforeEach } from 'vitest';
+import { BitmapFont, Image } from '../index.js';
 
 describe('BitmapFont', () => {
+	let ctx: CanvasRenderingContext2D;
+
+	beforeEach(() => {
+		const canvas: HTMLCanvasElement = document.createElement('canvas');
+		const temp = canvas.getContext('2d');
+		if (!temp) {
+			throw new Error('Could not get rendering context for testing');
+		}
+		ctx = temp;
+	});
 
 	afterEach(() => {
 		vi.resetAllMocks();
@@ -23,9 +33,6 @@ describe('BitmapFont', () => {
 
 	describe('addVariant()', () => {
 
-		const gameWindow: Window = window as any;
-		gameWindow.game = new Game();
-
 		const canvas: HTMLCanvasElement = document.createElement('canvas');
 		canvas.width = 40;
 		canvas.height = 60;
@@ -37,14 +44,11 @@ describe('BitmapFont', () => {
 				fromR: 0, fromG: 0, fromB: 0, toR: 255, toG: 255, toB: 255,
 			});
 			vi.spyOn(font, 'drawByIndex').mockImplementation(() => {});
-			expect(() => { font.drawString('      ', 0, 0, 'test'); }).not.toThrowError();
+			expect(() => { font.drawString(ctx, '      ', 0, 0, 'test'); }).not.toThrowError();
 		});
 	});
 
 	describe('drawString()', () => {
-
-		const gameWindow: Window = window as any;
-		gameWindow.game = new Game();
 
 		const canvas: HTMLCanvasElement = document.createElement('canvas');
 		canvas.width = 40;
@@ -54,7 +58,7 @@ describe('BitmapFont', () => {
 		it('renders all printable chars', () => {
 			const font = new BitmapFont(image, 10, 10, 0, 0, 2);
 			const drawByIndexSpy = vi.spyOn(font, 'drawByIndex');
-			font.drawString('      ', 0, 0);
+			font.drawString(ctx, '      ', 0, 0);
 			expect(drawByIndexSpy).toHaveBeenCalledTimes(6);
 		});
 
@@ -62,7 +66,7 @@ describe('BitmapFont', () => {
 
 			const font = new BitmapFont(image, 10, 10, 0, 0, 2);
 			const drawByIndexSpy = vi.spyOn(font, 'drawByIndex');
-			font.drawString(' \x13 ', 0, 0);
+			font.drawString(ctx, ' \x13 ', 0, 0);
 
 			// All 3 chars rendered are for font index 0
 			expect(drawByIndexSpy).toHaveBeenCalledTimes(3);
@@ -77,7 +81,7 @@ describe('BitmapFont', () => {
 
 			const font = new BitmapFont(image, 10, 10, 0, 0, 2);
 			const drawByIndexSpy = vi.spyOn(font, 'drawByIndex');
-			font.drawString(' \x70 ', 0, 0); // 0x70 > the font size of 6 chars
+			font.drawString(ctx, ' \x70 ', 0, 0); // 0x70 > the font size of 6 chars
 
 			// All 3 chars rendered are for font index 0
 			expect(drawByIndexSpy).toHaveBeenCalledTimes(3);
@@ -91,7 +95,7 @@ describe('BitmapFont', () => {
 		it('does not error if an invalid color is specified', () => {
 			const font = new BitmapFont(image, 10, 10, 0, 0, 2);
 			vi.spyOn(font, 'drawByIndex').mockImplementation(() => {});
-			expect(() => { font.drawString('      ', 0, 0, 'invalidVariant'); }).not.toThrowError();
+			expect(() => { font.drawString(ctx, '      ', 0, 0, 'invalidVariant'); }).not.toThrowError();
 		});
 	});
 });

--- a/src/gtp/BitmapFont.ts
+++ b/src/gtp/BitmapFont.ts
@@ -1,6 +1,5 @@
 import Image, { ColorChange } from './Image.js';
 import SpriteSheet from './SpriteSheet.js';
-import { Window } from './GtpBase.js';
 
 /**
  * Specifies the default color for this font in calls to drawString() (that is, the
@@ -34,11 +33,9 @@ export default class BitmapFont extends SpriteSheet {
 		this.fontMap[color] = this.createRecoloredCopy(...colorChanges);
 	}
 
-	drawString(str: string, x: number, y: number, color = DEFAULT_COLOR) {
+	drawString(ctx: CanvasRenderingContext2D, str: string, x: number, y: number, color = DEFAULT_COLOR) {
 
 		const glyphCount: number = this.size;
-		const gameWindow: Window = window as any;
-		const ctx: CanvasRenderingContext2D = gameWindow.game.getRenderingContext();
 		const charWidth: number = this.cellW;
 		const variant = this.fontMap[color] ?? this;
 

--- a/src/gtp/FadeOutInState.spec.ts
+++ b/src/gtp/FadeOutInState.spec.ts
@@ -1,6 +1,5 @@
-import { Mock, MockInstance } from 'vitest';
-import { State, FadeOutInState } from '../index.js';
-import Game from './Game.js';
+import { beforeEach, Mock, MockInstance } from 'vitest';
+import { State, FadeOutInState, Game } from '../index.js';
 
 interface FunctionWrapperForTesting {
 	transitionLogic: () => string;
@@ -8,14 +7,21 @@ interface FunctionWrapperForTesting {
 
 describe('FadeOutInState', () => {
 
+	let game: Game;
+
+	beforeEach(() => {
+		game = new Game();
+	});
+
 	afterEach(() => {
 		vi.resetAllMocks();
+		vi.restoreAllMocks();
 	});
 
 	it('constructor happy path', () => {
 
-		const leavingState: State<Game> = new State<Game>();
-		const enteringState: State<Game> = new State<Game>();
+		const leavingState: State<Game> = new State<Game>(game);
+		const enteringState: State<Game> = new State<Game>(game);
 		const temp: FunctionWrapperForTesting = {
 			transitionLogic: vi.fn(),
 		};
@@ -48,8 +54,8 @@ describe('FadeOutInState', () => {
 			} as Game;
 
 			gameSetStateSpy = vi.spyOn(game, 'setState');
-			mockLeavingState = new State<Game>();
-			mockEnteringState = new State<Game>();
+			mockLeavingState = new State<Game>(game);
+			mockEnteringState = new State<Game>(game);
 			mockLeavingRenderSpy = vi.spyOn(mockLeavingState, 'render').mockImplementation(() => {
 			});
 			mockEnteringRenderSpy = vi.spyOn(mockEnteringState, 'render').mockImplementation(() => {
@@ -59,7 +65,7 @@ describe('FadeOutInState', () => {
 			timeMillis = 500;
 
 			fadeState = new FadeOutInState<Game>(mockLeavingState, mockEnteringState, transitionLogicSpy, timeMillis);
-			fadeState.enter(game);
+			fadeState.enter();
 
 			vi.useFakeTimers();
 		});
@@ -135,8 +141,8 @@ describe('FadeOutInState', () => {
 
 	it('transitionLogic is called at halfway point', () => {
 
-		const leavingState: State<Game> = new State<Game>();
-		const enteringState: State<Game> = new State<Game>();
+		const leavingState: State<Game> = new State<Game>(game);
+		const enteringState: State<Game> = new State<Game>(game);
 		const temp: FunctionWrapperForTesting = {
 			transitionLogic: vi.fn(),
 		};

--- a/src/gtp/FadeOutInState.ts
+++ b/src/gtp/FadeOutInState.ts
@@ -27,7 +27,7 @@ export default class FadeOutInState<T extends Game> extends State<T> {
 	 */
 	constructor(leavingState: State<T>, enteringState: State<T>,
 		transitionLogic?: TransitionLogicCallback, timeMillis?: number) {
-		super();
+		super(enteringState.game);
 		this.leavingState = leavingState;
 		this.enteringState = enteringState;
 		this.transitionLogic = transitionLogic;
@@ -35,11 +35,6 @@ export default class FadeOutInState<T extends Game> extends State<T> {
 		this.alpha = 1;
 		this.halfTime = timeMillis && timeMillis > 0 ? timeMillis / 2 : DEFAULT_HALF_TIME_MILLIS;
 		this.curTime = 0;
-	}
-
-	override enter(game: T) {
-		super.enter(game);
-		this.game = game;
 	}
 
 	override update(delta: number) {

--- a/src/gtp/Game.spec.ts
+++ b/src/gtp/Game.spec.ts
@@ -101,7 +101,7 @@ describe('Game', () => {
 		});
 		game.toggleShowFps();
 
-		game.setState(new DummyState());
+		game.setState(new DummyState(game));
 
 		expect(() => { game.render(); }).not.toThrowError();
 	});
@@ -109,7 +109,7 @@ describe('Game', () => {
 	it('start() starts an event loop', async() => {
 
 		const game: Game = new Game();
-		game.setState(new DummyState());
+		game.setState(new DummyState(game));
 		game.start();
 		game.toggleShowFps();
 

--- a/src/gtp/Game.ts
+++ b/src/gtp/Game.ts
@@ -55,8 +55,6 @@ export default class Game {
 
 	constructor(args: GameArgs = { width: 640, height: 480 }) {
 
-		Utils.initConsole();
-
 		this.scale = args.scale ?? 1;
 		this.canvas = ImageUtils.createCanvas(args.width, args.height, args.parent);
 
@@ -225,10 +223,10 @@ export default class Game {
 
 	setState(state: State<Game>) {
 		if (this.state) {
-			this.state.leaving(this);
+			this.state.leaving();
 		}
 		this.state = state;
-		this.state.enter(this);
+		this.state.enter();
 	}
 
 	setStatusMessage(message: string) {

--- a/src/gtp/State.spec.ts
+++ b/src/gtp/State.spec.ts
@@ -1,10 +1,11 @@
-import { State } from '../index.js';
+import { Game, State } from '../index.js';
 
 describe('State', () => {
 
 	it('constructor happy path', () => {
+		const game = new Game();
 		expect(() => {
-			new State();
+			new State(game);
 		}).not.toThrowError();
 	});
 });

--- a/src/gtp/State.ts
+++ b/src/gtp/State.ts
@@ -1,12 +1,4 @@
 import Game from './Game.js';
-import { Window } from './GtpBase.js';
-
-/**
- * Arguments to pass to a state's constructor.
- */
-export interface BaseStateArgs<T extends Game> {
-	game: T;
-}
 
 /**
  * A base class for game states.  Basically just an interface with callbacks
@@ -14,40 +6,31 @@ export interface BaseStateArgs<T extends Game> {
  */
 export class State<T extends Game> {
 
-	game: T;
+	readonly game: T;
 
 	/**
 	 * A base class for game states.  Basically just an interface with callbacks
 	 * for updating and rendering, along with other lifecycle-ish methods.
-	 * @param args Arguments to the game state.
+	 * @param game The parent game.
 	 */
-	constructor(args?: T | BaseStateArgs<T>) {
-		if (args && args instanceof Game) {
-			this.game = args;
-		} else if (args) {
-			this.game = args.game;
-		} else { // Default to global game object
-			const gameWindow: Window = window as any;
-			this.game = gameWindow.game as T;
-		}
+	constructor(game: T) {
+		this.game = game;
 	}
 
 	/**
 	 * Called right before a state starts.  Subclasses can do any needed
 	 * initialization here.
-	 * @param game The game being played.
 	 * @see leaving
 	 */
-	enter(game: T) {
+	enter() {
 		// Subclasses can override
 	}
 
 	/**
 	 * Called when this state is being left for another one.
-	 * @param game The game being played.
 	 * @see enter
 	 */
-	leaving(game: T) {
+	leaving() {
 	}
 
 	/**

--- a/src/gtp/Utils.spec.ts
+++ b/src/gtp/Utils.spec.ts
@@ -87,26 +87,4 @@ describe('Utils', () => {
 		const end: number = Utils.timestamp();
 		expect(end).toBeGreaterThan(start + 1);
 	});
-
-	it('initConsole() with console defined', () => {
-		const mockConsole: any = {
-			info: 1,
-			log: 2,
-			warn: 3,
-			'error': 4,
-		};
-		const origConsole: Console = window.console;
-		(window as any).console = mockConsole;
-		Utils.initConsole();
-		expect((window as any).console).toBe(mockConsole);
-		(window as any).console = origConsole;
-	});
-
-	it('initConsole() with console undefined', () => {
-		const origConsole: Console = window.console;
-		(window as any).console = null;
-		Utils.initConsole();
-		expect(window.console).not.toBeNull();
-		(window as any).console = origConsole;
-	});
 });

--- a/src/gtp/Utils.ts
+++ b/src/gtp/Utils.ts
@@ -128,19 +128,4 @@ export default {
 		}
 		return Date.now(); // IE < 10
 	},
-
-	/**
-	 * Defines console functions for IE9 and other braindead browsers.
-	 */
-	initConsole() {
-		if (!window.console) {
-			const noOp = () => {};
-			(window as any).console = {
-				info: noOp,
-				log: noOp,
-				warn: noOp,
-				'error': noOp,
-			};
-		}
-	},
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ import Pool from './gtp/Pool.js';
 import Rectangle, { RectangularData } from './gtp/Rectangle.js';
 import Sound from './gtp/Sound.js';
 import SpriteSheet from './gtp/SpriteSheet.js';
-import { State, BaseStateArgs } from './gtp/State.js';
+import { State } from './gtp/State.js';
 import { StretchMode } from './gtp/StretchMode.js';
 import { SoundCompletedCallback } from './gtp/SoundCompletedCallback.js';
 import { TiledMapArgs } from './tiled/TiledMapArgs.js';
@@ -43,7 +43,6 @@ export {
 	AssetLoaderCallback,
 	AssetType,
 	AudioSystem,
-	BaseStateArgs,
 	BitmapFont,
 	BrowserUtil,
 	CanvasResizer,

--- a/src/tiled/TiledMap.spec.ts
+++ b/src/tiled/TiledMap.spec.ts
@@ -1,6 +1,8 @@
+import { afterEach } from 'vitest';
 import AssetLoader from '../gtp/AssetLoader.js';
 import AudioSystem from '../gtp/AudioSystem.js';
 import Utils from '../gtp/Utils.js';
+import Image from '../gtp/Image.js';
 import TiledMap from './TiledMap.js';
 import TiledLayer from './TiledLayer.js';
 import { TiledMapData } from './TiledMapData.js';
@@ -74,6 +76,10 @@ const simpleMapData: TiledMapData = {
 	width: 2,
 };
 
+const mockImage = {
+	drawScaled2: vi.fn(),
+} as unknown as Image;
+
 describe('TiledMap', () => {
 
 	let assets: AssetLoader;
@@ -83,6 +89,7 @@ describe('TiledMap', () => {
 
 		assets = new AssetLoader(1, new AudioSystem(), '');
 		assets.set('test-tiles.json', {});
+		vi.spyOn(assets, 'getTmxTilesetImage').mockReturnValue(mockImage);
 
 		const args: TiledMapArgs = {
 			screenWidth: 2,
@@ -90,6 +97,11 @@ describe('TiledMap', () => {
 			assets,
 		};
 		tiledMap = new TiledMap(simpleMapData, args);
+	});
+
+	afterEach(() => {
+		vi.resetAllMocks();
+		vi.restoreAllMocks();
 	});
 
 	it('constructor adds the proper number of layers, tilesets and properties', () => {
@@ -109,23 +121,11 @@ describe('TiledMap', () => {
 	});
 
 	it('draw() renders the map', () => {
-
-		const mockImage = {
-			drawScaled2: vi.fn(),
-		};
-
-		(window as any).game = {
-			assets: {
-				getTmxTilesetImage: () => {
-					return mockImage;
-				},
-			},
-		};
-
+		const drawScaled2Spy = vi.spyOn(mockImage, 'drawScaled2');
 		const canvas: HTMLCanvasElement = document.createElement('canvas');
 		const ctx: CanvasRenderingContext2D = Utils.getRenderingContext(canvas);
 		tiledMap.draw(ctx, 1, 1);
-		expect(mockImage.drawScaled2).toHaveBeenCalled();
+		expect(drawScaled2Spy).toHaveBeenCalled();
 	});
 
 	describe('getLayer()', () => {

--- a/src/tiled/TiledMap.ts
+++ b/src/tiled/TiledMap.ts
@@ -1,6 +1,5 @@
+import AssetLoader from '../gtp/AssetLoader.js';
 import Image from '../gtp/Image.js';
-import Game from '../gtp/Game.js';
-import { Window } from '../gtp/GtpBase.js';
 import TiledTileset, { scaleTileset, TiledImagePathModifier } from './TiledTileset.js';
 import TiledProperty from './TiledProperty.js';
 import { TiledMapData } from './TiledMapData.js';
@@ -38,6 +37,7 @@ export default class TiledMap implements TiledMapData, TiledPropertiesContainer 
 	version: string;
 	width: number;
 
+	assets: AssetLoader;
 	screenWidth: number;
 	screenHeight: number;
 	screenRows: number;
@@ -76,6 +76,7 @@ export default class TiledMap implements TiledMapData, TiledPropertiesContainer 
 		this.width = data.width;
 
 		// Properties we've added for convenience
+		this.assets = args.assets;
 		this.screenWidth = args.screenWidth;
 		this.screenHeight = args.screenHeight;
 		this.screenRows = Math.ceil(this.screenHeight / this.tileheight);
@@ -219,10 +220,7 @@ export default class TiledMap implements TiledMapData, TiledPropertiesContainer 
 			return;
 		}
 
-		const gameWindow: Window = window as any;
-		const game: Game = gameWindow.game;
-		const img: Image = game.assets.getTmxTilesetImage(tileset);
-
+		const img: Image = this.assets.getTmxTilesetImage(tileset);
 		const tileW: number = this.tilewidth;
 		const sw: number = tileW + tileset.spacing;
 		const tileH: number = this.tileheight;


### PR DESCRIPTION
Some parts of the code assumed there was a global `game` variable that could be referenced. Older consumers of this library would define `window.game = ...` to allow this to work. While this kept APIs simple, global variables make for hard unit testing, so this PR removes this feature. Code should always prop-drill the game instance, or whatefver subset of data is necessary, as needed.